### PR TITLE
Fix: Android restart after crash but stuck at splash screen

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/controllers/NavigationActivity.java
+++ b/android/app/src/main/java/com/reactnativenavigation/controllers/NavigationActivity.java
@@ -220,8 +220,12 @@ public class NavigationActivity extends AppCompatActivity implements DefaultHard
 
     private void destroyJsIfNeeded() {
         Log.e("killedBySystem value", killedBySystem + "");
-        if ( killedBySystem ) {
-            Log.e("killedBySystem return", "killedBySystem return");
+        if (killedBySystem) {
+            /**
+             * When the NavigationActivity is killed/restarted by the system, it's onCreate method launches the SplashActivity and kills itself.
+             * The new SplashActivity starts context initialization but that is broken in between by the onDestroy of the NavigationActivity we just killed.
+             * This fix adds a boolean to disable destruction of js in this case.
+             */
             return;
         }
         if (currentActivity == null || currentActivity.isFinishing()) {

--- a/android/app/src/main/java/com/reactnativenavigation/controllers/NavigationActivity.java
+++ b/android/app/src/main/java/com/reactnativenavigation/controllers/NavigationActivity.java
@@ -9,6 +9,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
 import android.text.TextUtils;
+import android.util.Log;
 import android.view.KeyEvent;
 import android.view.Window;
 
@@ -218,7 +219,9 @@ public class NavigationActivity extends AppCompatActivity implements DefaultHard
     }
 
     private void destroyJsIfNeeded() {
+        Log.e("killedBySystem value", killedBySystem + "");
         if ( killedBySystem ) {
+            Log.e("killedBySystem return", "killedBySystem return");
             return;
         }
         if (currentActivity == null || currentActivity.isFinishing()) {

--- a/android/app/src/main/java/com/reactnativenavigation/controllers/NavigationActivity.java
+++ b/android/app/src/main/java/com/reactnativenavigation/controllers/NavigationActivity.java
@@ -66,6 +66,8 @@ public class NavigationActivity extends AppCompatActivity implements DefaultHard
     private PermissionListener mPermissionListener;
     private boolean mFirstCreated = true;
 
+    private boolean killedBySystem = false;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -73,6 +75,7 @@ public class NavigationActivity extends AppCompatActivity implements DefaultHard
         if (!NavigationApplication.instance.getReactGateway().hasStartedCreatingContext() ||
                 getIntent() == null ||
                 getIntent().getBundleExtra("ACTIVITY_PARAMS_BUNDLE") == null) {
+            killedBySystem = true;
             SplashActivity.start(this);
             finish();
             return;
@@ -215,6 +218,9 @@ public class NavigationActivity extends AppCompatActivity implements DefaultHard
     }
 
     private void destroyJsIfNeeded() {
+        if ( killedBySystem ) {
+            return;
+        }
         if (currentActivity == null || currentActivity.isFinishing()) {
             getReactGateway().onDestroyApp(this);
         }


### PR DESCRIPTION
When the NavigationActivity is killed/restarted by the system, it's onCreate method launches the SplashActivity and kills itself. The new SplashActivity starts context initialization but that is broken in between by the onDestroy of the NavigationActivity we just killed. This fix adds a boolean to disable destruction of js in this case.