### PR TITLE
fix blank screen problem when quckily push and pop

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/screens/ScreenStack.java
+++ b/android/app/src/main/java/com/reactnativenavigation/screens/ScreenStack.java
@@ -304,7 +304,7 @@ public class ScreenStack {
     }
 
     public boolean canPop() {
-        return stack.size() > 1 && (!isPreviousScreenAttachedToWindow() || canForcePop());
+        return stack.size() > 1 && !isPreviousScreenAttachedToWindow()
     }
 
     private boolean canForcePop() {


### PR DESCRIPTION
描述：快速push、pop页面会导致应用停留在白屏。
原因：在backPressed(点击左上角返回按钮 / Home键)之后，会走到canPop方法。RNN本身维护了一个Stack保存着Screen信息，如果在canPop方法里判断canForcePop的话，canForcePop方法里面会销毁previousScreen，导致在pop栈的时候找不到保存在栈里面的Screen而停留在了白屏。